### PR TITLE
added guard if entries is undefined

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -306,7 +306,7 @@ Docker.prototype.buildImage = function(file, opts, callback) {
     const dockerignorePath = path.join(file.context, '.dockerignore')
     if (fs.existsSync(dockerignorePath)) {
       const dockerIgnore = ignore({ ignorecase: false }).add(fs.readFileSync(dockerignorePath).toString())
-      entries = entries.filter(dockerIgnore.createFilter())
+      entries = (entries || []).filter(dockerIgnore.createFilter())
     }
 
     var pack = tar.pack(file.context, {


### PR DESCRIPTION
# Overview
The entries variable originates from the ops.yml src field which is optional and not defaulted in many of our init templates so I've added a guard incase it's not provided. 

# Impact
Ops.yml src being an optional field will likely impact the newly added ,dockerignore filter logic.

# Possible solutions 
When file.src is undefined we read in files from the cwd and filter against those files.